### PR TITLE
Add composer-generated compiled.php to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 .env-localhost
 .env-bluehost
 .htaccess
+vendor/compiled.php


### PR DESCRIPTION
My `composer install` generated a new `vendor/compiled.php` file which should probably be in gitignore. (unless I'm doing the setup strangely somehow!)