### PR TITLE
Add a default sender address to config/mail.php

### DIFF
--- a/config/mail.php
+++ b/config/mail.php
@@ -54,7 +54,7 @@ return [
 	|
 	*/
 
-	'from' => ['address' => null, 'name' => null],
+	'from' => ['address' => 'no-reply@ourworldindata.org', 'name' => null],
 
 	/*
 	|--------------------------------------------------------------------------


### PR DESCRIPTION
This lets password resets work with mailtrap and other smtp hosts where
the username is not an email address.